### PR TITLE
allow assert_not_null to be overriden

### DIFF
--- a/macros/etc/assert_not_null.sql
+++ b/macros/etc/assert_not_null.sql
@@ -1,4 +1,8 @@
-{% macro assert_not_null(function, arg) %}
+{% macro assert_not_null(function, arg) -%}
+  {{ return(adapter.dispatch('assert_not_null', 'spark_utils')(function, arg)) }}
+{%- endmacro %}
+
+{% macro default__assert_not_null(function, arg) %}
 
     coalesce({{function}}({{arg}}), nvl2({{function}}({{arg}}), assert_true({{function}}({{arg}}) is not null), null))
 


### PR DESCRIPTION
Macro assert_not_null should allow base project to override functionality
For this I added caller to adapter.dispatch