### PR TITLE
Upgrade to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,12 @@
+# spark-utils v0.3.0
+This release supports any version (minor and patch) of v1, which means far less need for compatibility releases in the future.
+
+### Features
+- Add macros for common maintenance operations ([#18](https://github.com/dbt-labs/spark-utils/pull/18))
+
+### Contributors
+- [@JCZuurmond](https://github.com/JCZuurmond) ([#18](https://github.com/dbt-labs/dbt-external-tables/pull/18))
+- [@NielsZeilemaker](https://github.com/NielsZeilemaker) ([#18](https://github.com/dbt-labs/dbt-external-tables/pull/18))
+
 # spark-utils v0.2.4
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ The spark-utils package may be able to provide compatibility for your package, e
 
 ----
 
+## Useful macros: maintenance
+
+_Caveat: These are not tested in CI, or guaranteed to work on all platforms._
+
+Each of these macros accepts a regex pattern, finds tables with names matching the pattern, and will loop over those tables to perform a maintenance operation:
+
+- `spark_optimize_delta_tables`: Runs `optimize` for all matched Delta tables
+- `spark_vacuum_delta_tables`: Runs `vacuum` for all matched Delta tables
+- `spark_analyze_tables`: Compute statistics for all matched tables
+
+----
+
 ### Contributing
 
 We welcome contributions to this repo! To contribute a new feature or a fix, 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'spark_utils'
-version: '0.2.4'
+version: '0.3.0'
 config-version: 2
-
-require-dbt-version: [">=0.18.0", "<1.1.0"]
+require-dbt-version: [">=1.0.0", "<2.0.0"]
+macro-paths: ["macros"]


### PR DESCRIPTION
- **`dbt_project.yml`**: Update package version. Explicitly specify `macro-path` (you never know). Bump dbt version requirements to `[">=1.0.0", "<2.0.0"]` — this isn't strictly necessary, as there aren't any backwards-incompatible changes, but it's neater for all of us going forward.
- Update changelog
- Document #18 in readme