### PR TITLE
feature/dbt-expectations-shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# spark-utils v0.3.1
+### Features
+- Added `dbt_expectations` folder to allow for spark dispatches of the popular macros within the [dbt_expectations](https://github.com/calogica/dbt-expectations) package.
+- Addition of the spark shim for the dbt-expectations `regexp_instr` macro.
+
 # spark-utils v0.3.0
 This release supports any version (minor and patch) of v1, which means far less need for compatibility releases in the future.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This package provides "shims" for:
     - `dbt_utils.listagg`
     - `dbt_utils.pivot` with apostrophe(s) in the `values` 
 - [snowplow](https://github.com/dbt-labs/snowplow) (tested on Databricks only)
+- [dbt-expectations](https://github.com/calogica/dbt-expectations) select macros:
+   - `dbt_expectations.regexp_instr`
 
 In order to use these "shims," you should set a `dispatch` config in your root project (on dbt v0.20.0 and newer). For example, with this project setting, dbt will first search for macro implementations inside the `spark_utils` package when resolving macros from the `dbt_utils` namespace:
 ```

--- a/macros/dbt_expectations/regexp_instr.sql
+++ b/macros/dbt_expectations/regexp_instr.sql
@@ -1,0 +1,3 @@
+{% macro spark__regexp_instr(source_value, regexp, position=1, occurrence=1, is_raw=False) %}
+regexp_instr({{ source_value }}, '{{ regexp }}')
+{% endmacro %}


### PR DESCRIPTION
PR to address Issue #29 

This PR adds a folder for shims of dbt-expectations macros. Specifically, this PR only adds a spark shim for the `regexp_instr` macro. This may be expanded in future PRs to add other shims for macros within this package.

I did not add anything to the integration_tests folder. Let me know if there are any updates needed on my end for this to be incorporated. A working implementation currently exists within the Fivetran [dbt_google_ads_source](https://github.com/fivetran/dbt_google_ads_source/blob/main/macros/regexp_instr.sql) package. The intention will be to remove this macro from the Fivetran package and into spark-utils for use by all.