### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v3
 
      - name: Set up Python 3.9
-       uses: actions/setup-python@v2
+       uses: actions/setup-python@v4
        with:
          python-version: 3.9
 


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144