### PR TITLE
spark__get_relations_by_pattern now respects database given

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ for more information on installing packages.
 
 This package provides "shims" for:
 - [dbt_utils](https://github.com/dbt-labs/dbt-utils), except for:
-    - `dbt_utils.get_relations_by_pattern`
     - `dbt_utils.groupby`
     - `dbt_utils.recency`
     - `dbt_utils.any_value`

--- a/macros/dbt_utils/sql/get_relations_by_prefix.sql
+++ b/macros/dbt_utils/sql/get_relations_by_prefix.sql
@@ -1,5 +1,9 @@
 {% macro spark__get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
+    {%- call statement('change_database', fetch_result=False) %}
+        USE CATALOG {{ database }}
+    {%- endcall -%}
+
     {%- call statement('get_tables', fetch_result=True) %}
 
         show table extended in {{ schema_pattern }} like '{{ table_pattern }}'


### PR DESCRIPTION
This just makes it so the database to spark__get_relations_by_pattern actually does something.  Currently it seems to ONLY do the target.database.  

Unclear what to do about testing since at least the integration test seems to be [explicitly disabled](https://github.com/dbt-labs/spark-utils/blob/main/integration_tests/dbt_utils/dbt_project.yml#L35-L37) 3 years ago.  

Happy to do whatever else. 