### PR TITLE
Updates for Fusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /**/env/
 /**/__pycache__/
 test.env
+dbt_internal_packages/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,5 +2,5 @@ name: 'spark_utils'
 profile: 'sparkutils'
 version: '0.3.0'
 config-version: 2
-require-dbt-version: [">=1.2.0", "<2.0.0"]
+require-dbt-version: [">=1.2.0", "<3.0.0"]
 macro-paths: ["macros"]

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -1,21 +1,15 @@
-
 name: 'spark_utils_dbt_utils_integration_tests'
 version: '1.0'
 config-version: 2
 
 profile: 'integration_tests'
 
-source-paths: ["models"]
-analysis-paths: ["analysis"] 
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
 macro-paths: ["macros"]
-
-target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
-    - "target"
-    - "dbt_modules"
-    
+  - "target"
+  - "dbt_modules"
 dispatch:
   - macro_namespace: dbt_utils
     search_order:
@@ -57,4 +51,8 @@ tests:
       # expect exactly two failures
       # (both use "order by", which isn't supported in SparkSQL)
       assert_equal_test_listagg_actual__expected:
-        error_if: ">2"
+        +error_if: ">2"
+flags:
+  require_generic_test_arguments_property: true
+seed-paths: ["data"]
+model-paths: ["models"]

--- a/integration_tests/snowplow/dbt_project.yml
+++ b/integration_tests/snowplow/dbt_project.yml
@@ -1,20 +1,15 @@
-
 name: 'spark_utils_snowplow_integration_tests'
 version: '1.0'
 config-version: 2
 
 profile: 'integration_tests'
 
-source-paths: ["models"]
-analysis-paths: ["analysis"] 
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
 macro-paths: ["macros"]
-
-target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
-    - "target"
-    - "dbt_modules"
+  - "target"
+  - "dbt_modules"
 
 dispatch:
   - macro_namespace: dbt_utils
@@ -23,9 +18,6 @@ dispatch:
     search_order: ['spark_utils', 'snowplow']
 
 models:
-  incremental_strategy: merge
-  file_format: delta
-  
   snowplow_integration_tests:
     pre:
       default:
@@ -41,17 +33,16 @@ models:
           sessions_expected:
             +enabled: false
 
+  +incremental_strategy: merge
+  +file_format: delta
 vars:
   'snowplow:timezone': 'America/New_York'
   'snowplow:events': '{{ ref("base_event") }}'
   'snowplow:context:web_page': '{{ ref("base_web_page") }}'
-  'snowplow:context:performance_timing': FALSE
-  'snowplow:context:useragent': FALSE
+  'snowplow:context:performance_timing': false
+  'snowplow:context:useragent': false
   'snowplow:pass_through_columns': ['test_add_col']
-    
 seeds:
-  quote_columns: false
-  
   snowplow_integration_tests:
     event:
       +column_types:
@@ -77,3 +68,8 @@ seeds:
         +column_types:
           session_start: string
           session_end: string
+  +quote_columns: false
+flags:
+  require_generic_test_arguments_property: true
+seed-paths: ["data"]
+model-paths: ["models"]


### PR DESCRIPTION
I haven't been able to run the full suite of integration tests on Fusion as the testing approach is pretty outdated and I don't have easy access to Spark but from what I see the package as-is should work fine in Fusion as it mostly consists of macros that use basic Jinja syntax (loops etc...)